### PR TITLE
fixes text-align when centering cells on tables

### DIFF
--- a/public/stylesheets/tweaks/CSS/tweaks.css
+++ b/public/stylesheets/tweaks/CSS/tweaks.css
@@ -199,6 +199,7 @@
   justify-content: center !important;
   margin-left: auto !important;
   margin-right: auto !important;
+  text-align: center !important;
 }
 .--nst_tweak-rounded-table-checkboxes .notion-table-view .notion-collection-item [style*='padding: 8px;'] {
   padding: 0 !important;


### PR DESCRIPTION
Hi Eli! 
I noticed a problem when enabling "Center all cells" on tables. 
So I just added a "text-align: center !important" on these columns. 

Here's a image showing how it was before:
![PR](https://user-images.githubusercontent.com/74937642/158323494-340294e3-c175-4c1b-92d4-fc45eff283f8.png)
 